### PR TITLE
Use 'npm ci' instead of 'npm install'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         node-version: ${{ matrix.node }}
 
     - name: Install dependencies
-      run: npm install
+      run: npm ci
 
     - name: Test
       run: npm run test


### PR DESCRIPTION
**Ticket**
[48](https://github.com/openedx/frontend-wg/issues/48)

**Description:**
Used 'npm ci' instead of 'npm install' to install dependencies